### PR TITLE
⬆️ Upgrade Transifex cli.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,7 @@ jobs:
         source /home/runner/work/.venv/bin/activate
         pip install -U pip setuptools wheel
         pip install -r ./requirements.txt
+        curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
         deactivate
     - name: update
       env:


### PR DESCRIPTION
Subject: ⬆️ Upgrade Transifex cli.

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
- Upgrade Transifex CLI dependencies.

### Detail
- The deprecation period of API 2.0/2.5 and Transifex CLI is coming to an end. Calls to these APIs and any scripts that depend on them will not work after Nov 30, 2022. We highly recommend you migrate to newer versions before the sunset date.

### Relates
- https://github.com/transifex/cli